### PR TITLE
correction of documentation comments of nvim-java and jdtls settings

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -702,11 +702,11 @@ require('lazy').setup({
       }
 
       require('java').setup {
-        -- Your custom jdtls settings goes here
+        -- Your custom nvim-java settings go here
       }
 
       require('lspconfig').jdtls.setup {
-        -- Your custom nvim-java configuration goes here
+        -- Your custom jdtls configuration goes here
       }
 
       -- The following loop will configure each server with the capabilities we defined above.


### PR DESCRIPTION
comments are fixed based on the guide on README.md.

